### PR TITLE
close all opporunities of an account

### DIFF
--- a/force-app/main/default/classes/trgHandler.cls
+++ b/force-app/main/default/classes/trgHandler.cls
@@ -1,0 +1,41 @@
+public class trgHandler
+{
+public static void trgMethod(List<Account> accList,Map<Id,Account> oldMap)
+{
+Set<Id> accIds = new Set<Id>();
+
+if(!accList.isEmpty())
+{
+for(Account ac : accList)
+{
+if(ac.Close_all_Opps__c == true && oldMap.containsKey(ac.Id) && oldMap.get(ac.Id).Close_all_Opps__c == false)
+{
+accIds.add(ac.Id);
+}
+}
+}
+
+if(!accIds.isEmpty())
+{
+List<Opportunity> oppList = [Select Id,AccountId,Stagename from Opportunity where AccountId IN : accIds
+and Stagename != 'Closed Won' and Probability >= 70];
+
+List<Opportunity> listToUpdate = new List<Opportunity>();
+
+if(!oppList.isEmpty())
+{
+for(Opportunity opp : oppList)
+{
+opp.Stagename = 'Closed Won';
+opp.CloseDate = date.today();
+listToUpdate.add(opp);
+}
+}
+
+if(!listToUpdate.isEmpty())
+{
+update listToUpdate;
+}
+}
+}
+}

--- a/force-app/main/default/classes/trgHandler.cls-meta.xml
+++ b/force-app/main/default/classes/trgHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/triggers/closeOppTrg.trigger
+++ b/force-app/main/default/triggers/closeOppTrg.trigger
@@ -1,0 +1,13 @@
+//Business Use Case: Let’s say a sales rep is working on an account and marks the “Close_all_Opps__c” field as true. 
+//Without this trigger, they would have to manually go through each open opportunity for that account and close them as won, 
+//which can be time-consuming and prone to errors. With this trigger in place, the opportunities will be automatically closed 
+//as won if they meet the criteria specified in the code.
+
+
+trigger closeOppTrg on Account (after Update)
+{
+if(trigger.isAfter && trigger.isUpdate)
+{
+trgHandler.trgMethod(trigger.new,trigger.oldMap);
+}
+}

--- a/force-app/main/default/triggers/closeOppTrg.trigger-meta.xml
+++ b/force-app/main/default/triggers/closeOppTrg.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>59.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
Business Use Case: Let’s say a sales rep is working on an account and marks the “Close_all_Opps__c” field as true. Without this trigger, they would have to manually go through each open opportunity for that account and close them as won, which can be time-consuming and prone to errors. With this trigger in place, the opportunities will be automatically closed as won if they meet the criteria specified in the code.